### PR TITLE
Fix license key in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "licenses": [
     {
-      "name": "Apache License 2.0",
+      "type": "Apache License 2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     }
   ]


### PR DESCRIPTION
The key should be "type", not "name".

I encountered this when I was scanning a project's licenses with licence-checker and it reported the license of this package as unknown.